### PR TITLE
Add simple MERN management example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# ShopEasy
+# ShopEasy Management
 
-This is a simple e-commerce website built with **Next.js** and **React**. It includes basic pages for a home screen, product listings, and a shopping cart.
+This repository contains a simple MERN stack management system built on top of the original ShopEasy Next.js demo. The frontend is implemented with **Next.js** and **React**, while the backend uses **Express** and **MongoDB** via **Mongoose**.
 
-## Getting Started
+## Frontend
 
-Install dependencies (requires access to npm registry) and start the development server:
+The frontend lives in the root of the project and can be started as usual:
 
 ```bash
 npm install
@@ -17,3 +17,35 @@ Build for production:
 npm run build
 npm start
 ```
+
+Visit `http://localhost:3000/tasks` to see a very basic task management page that communicates with the backend server.
+
+## Backend
+
+The backend is located in the `backend/` directory.
+
+1. Install dependencies (requires access to npm registry):
+
+```bash
+cd backend
+npm install
+```
+
+2. Copy `.env.example` to `.env` and adjust the MongoDB connection string if necessary.
+
+3. Start the server:
+
+```bash
+npm start
+```
+
+The server listens on `http://localhost:5000` by default and exposes REST endpoints under `/api/tasks`.
+
+## Project Structure
+
+```
+/              - Next.js frontend
+/backend       - Express/Mongoose backend
+```
+
+This setup provides a minimal example of a MERN stack application with database connectivity.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,2 @@
+MONGODB_URI=mongodb://localhost:27017/management
+PORT=5000

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "management-backend",
+  "version": "1.0.0",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "dev": "nodemon server.js"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.18.2",
+    "mongoose": "^7.0.0"
+  },
+  "devDependencies": {
+    "nodemon": "^3.0.0"
+  }
+}

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,0 +1,50 @@
+const express = require('express');
+const mongoose = require('mongoose');
+const cors = require('cors');
+require('dotenv').config();
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+const mongoUri = process.env.MONGODB_URI || 'mongodb://localhost:27017/management';
+mongoose.connect(mongoUri, {
+  useNewUrlParser: true,
+  useUnifiedTopology: true,
+});
+
+const taskSchema = new mongoose.Schema({
+  title: { type: String, required: true },
+  description: String,
+  status: { type: String, default: 'TODO' },
+});
+
+const Task = mongoose.model('Task', taskSchema);
+
+app.get('/api/tasks', async (req, res) => {
+  const tasks = await Task.find();
+  res.json(tasks);
+});
+
+app.post('/api/tasks', async (req, res) => {
+  const task = new Task(req.body);
+  await task.save();
+  res.status(201).json(task);
+});
+
+app.put('/api/tasks/:id', async (req, res) => {
+  const task = await Task.findByIdAndUpdate(req.params.id, req.body, { new: true });
+  if (!task) return res.status(404).end();
+  res.json(task);
+});
+
+app.delete('/api/tasks/:id', async (req, res) => {
+  const result = await Task.findByIdAndDelete(req.params.id);
+  if (!result) return res.status(404).end();
+  res.status(204).end();
+});
+
+const port = process.env.PORT || 5000;
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});

--- a/pages/tasks.js
+++ b/pages/tasks.js
@@ -1,0 +1,62 @@
+import { useEffect, useState } from 'react';
+import Head from 'next/head';
+import Link from 'next/link';
+
+export default function Tasks() {
+  const [tasks, setTasks] = useState([]);
+  const [form, setForm] = useState({ title: '', description: '' });
+
+  useEffect(() => {
+    fetch('http://localhost:5000/api/tasks')
+      .then(res => res.json())
+      .then(setTasks)
+      .catch(console.error);
+  }, []);
+
+  const submitTask = async (e) => {
+    e.preventDefault();
+    const res = await fetch('http://localhost:5000/api/tasks', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(form),
+    });
+    const newTask = await res.json();
+    setTasks([...tasks, newTask]);
+    setForm({ title: '', description: '' });
+  };
+
+  return (
+    <div>
+      <Head>
+        <title>Task Management</title>
+      </Head>
+      <h1>Tasks</h1>
+      <nav>
+        <Link href="/">Home</Link>
+      </nav>
+
+      <form onSubmit={submitTask} style={{ marginTop: '1rem' }}>
+        <input
+          placeholder="Title"
+          value={form.title}
+          onChange={e => setForm({ ...form, title: e.target.value })}
+          required
+        />
+        <input
+          placeholder="Description"
+          value={form.description}
+          onChange={e => setForm({ ...form, description: e.target.value })}
+        />
+        <button type="submit">Add Task</button>
+      </form>
+
+      <ul>
+        {tasks.map(task => (
+          <li key={task._id}>
+            <strong>{task.title}</strong> - {task.description}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add Express/Mongoose backend
- document environment setup in README
- add task management page to the Next.js frontend

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845264fbbec832b9afd45c72b52ea07